### PR TITLE
deps: Bump minimum required version of spanner-graph-notebook to 1.1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extras = {
     "bigframes": ["bigframes >= 1.17.0"],
     "geopandas": ["geopandas >= 1.0.1"],
     "spanner-graph-notebook": [
-        "spanner-graph-notebook >= 1.1.3",
+        "spanner-graph-notebook >= 1.1.5",
         "portpicker",
     ],
 }


### PR DESCRIPTION
This fixes an issue where forcegraph is unavailable for external server.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-magics/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
