### PR TITLE
deps: move spanner-graph-notebook back to version 1.1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extras = {
     "bigframes": ["bigframes >= 1.17.0"],
     "geopandas": ["geopandas >= 1.0.1"],
     "spanner-graph-notebook": [
-        "spanner-graph-notebook >= 1.1.5",
+        "spanner-graph-notebook >= 1.1.5, <= 1.1.6",
         "portpicker",
     ],
 }


### PR DESCRIPTION
Spanner-graph-notebok version 1.1.7 breaks BQ graph visualizers; rolling back to version 1.1.6 to fix.