### PR TITLE
chore: add missing kokoro configs following up to 3.7 and 3.8 drop

### DIFF
--- a/.kokoro/presubmit/prerelease-deps-3.10.cfg
+++ b/.kokoro/presubmit/prerelease-deps-3.10.cfg
@@ -3,5 +3,5 @@
 # Only run this nox session.
 env_vars: {
     key: "NOX_SESSION"
-value: "prerelease_deps-3.9"
+value: "prerelease_deps-3.10"
 }

--- a/.kokoro/presubmit/prerelease-deps-3.10.cfg
+++ b/.kokoro/presubmit/prerelease-deps-3.10.cfg
@@ -3,5 +3,5 @@
 # Only run this nox session.
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.8"
+value: "prerelease_deps-3.9"
 }

--- a/.kokoro/presubmit/prerelease-deps-3.9.cfg
+++ b/.kokoro/presubmit/prerelease-deps-3.9.cfg
@@ -3,5 +3,5 @@
 # Only run this nox session.
 env_vars: {
     key: "NOX_SESSION"
-    value: "prerelease_deps-3.8"
+value: "prerelease_deps-3.9"
 }

--- a/.kokoro/presubmit/system-3.10.cfg
+++ b/.kokoro/presubmit/system-3.10.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "system-3.10"
+}

--- a/.kokoro/presubmit/system-3.9.cfg
+++ b/.kokoro/presubmit/system-3.9.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "system-3.9"
+}

--- a/noxfile.py
+++ b/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "psutil",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []


### PR DESCRIPTION
Follow-up to https://github.com/googleapis/python-bigquery-magics/pull/127

Closes https://github.com/googleapis/python-bigquery-magics/issues/144
🦕
