### PR TITLE
chore: librarian release pull request: 20251215T173820Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: bigquery-magics
-    version: 0.10.3
+    version: 0.11.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/bigquery-magics/#history
 
+## [0.11.0](https://github.com/googleapis/google-cloud-python/compare/bigquery-magics-v0.10.3...bigquery-magics-v0.11.0) (2025-12-16)
+
+
+### Features
+
+* support python 3.14 (#165) ([8ee73ecf20636eed124b80f76a364ca990acd5fe](https://github.com/googleapis/google-cloud-python/commit/8ee73ecf20636eed124b80f76a364ca990acd5fe))
+
 ## [0.10.3](https://github.com/googleapis/python-bigquery-magics/compare/v0.10.2...v0.10.3) (2025-08-21)
 
 

--- a/bigquery_magics/version.py
+++ b/bigquery_magics/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.10.3"
+__version__ = "0.11.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>bigquery-magics: 0.11.0</summary>

## [0.11.0](https://github.com/googleapis/python-bigquery-magics/compare/v0.10.3...v0.11.0) (2025-12-15)

### Features

* support python 3.14 (#165) ([8ee73ecf](https://github.com/googleapis/python-bigquery-magics/commit/8ee73ecf))

</details>