### PR TITLE
fix: reduce conflicts between Spanner and BigQuery graph visualization on Colab

### DIFF
--- a/bigquery_magics/bigquery.py
+++ b/bigquery_magics/bigquery.py
@@ -680,9 +680,11 @@ def _add_graph_widget(query_result):
     try:
         from google.colab import output
 
-        output.register_callback("graph_visualization.Query", _colab_query_callback)
         output.register_callback(
-            "graph_visualization.NodeExpansion", _colab_node_expansion_callback
+            "bigquery.graph_visualization.Query", _colab_query_callback
+        )
+        output.register_callback(
+            "bigquery.graph_visualization.NodeExpansion", _colab_node_expansion_callback
         )
 
         # In colab mode, the Javascript doesn't use the port value we pass in, as there is no
@@ -702,6 +704,13 @@ def _add_graph_widget(query_result):
         query="placeholder query",
         port=port,
         params=query_result.to_json().replace("\\", "\\\\").replace('"', '\\"'),
+    )
+    html_content = html_content.replace(
+        '"graph_visualization.Query"', '"bigquery.graph_visualization.Query"'
+    )
+    html_content = html_content.replace(
+        '"graph_visualization.NodeExpansion"',
+        '"bigquery.graph_visualization.NodeExpansion"',
     )
     IPython.display.display(IPython.core.display.HTML(html_content))
 


### PR DESCRIPTION
…d Spanner. This avoids clashes if the same notebook uses visualizers for both BigQuery graphs and Spanner graphs, which can cause malfunctions in the visualizers.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-magics/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
