### PR TITLE
feat: remove bqsql magic to make that name available for bigframes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,15 +101,3 @@ Perform a query
     GROUP BY name
     ORDER BY count DESC
     LIMIT 3
-
-Since BigQuery supports Python via BigQuery DataFrames, `%%bqsql` is offered as
-an alias to clarify the language of these cells.
-
-.. code:: python
-
-    %%bqsql
-    SELECT name, SUM(number) as count
-    FROM 'bigquery-public-data.usa_names.usa_1910_current'
-    GROUP BY name
-    ORDER BY count DESC
-    LIMIT 3

--- a/bigquery_magics/__init__.py
+++ b/bigquery_magics/__init__.py
@@ -30,7 +30,6 @@ def load_ipython_extension(ipython):
     ipython.register_magic_function(
         _cell_magic, magic_kind="cell", magic_name="bigquery"
     )
-    ipython.register_magic_function(_cell_magic, magic_kind="cell", magic_name="bqsql")
 
     global is_registered
     is_registered = True

--- a/bigquery_magics/bigquery.py
+++ b/bigquery_magics/bigquery.py
@@ -14,13 +14,13 @@
 
 """IPython Magics
 
-.. function:: ``%%bigquery`` or ``%%bqsql``
+.. function:: ``%%bigquery``
 
     IPython cell magic to run a query and display the result as a DataFrame
 
     .. code-block:: python
 
-        %%bqsql [<destination_var>] [--project <project>] [--use_legacy_sql]
+        %%bigquery [<destination_var>] [--project <project>] [--use_legacy_sql]
                    [--verbose] [--params <params>]
         <query>
 

--- a/docs/magics.rst
+++ b/docs/magics.rst
@@ -8,7 +8,7 @@ in a Jupyter notebook cell.
 
     %load_ext bigquery_magics
 
-This makes the ``%%bigquery`` and ``%%bqsql`` magics available.
+This makes the ``%%bigquery`` magic available.
 
 Code Samples
 ------------

--- a/tests/unit/bigquery/test_bigquery.py
+++ b/tests/unit/bigquery/test_bigquery.py
@@ -339,9 +339,7 @@ def test__create_dataset_if_necessary_not_exist():
 
 @pytest.mark.parametrize(
     ("magic_name",),
-    (
-        ("bigquery",),
-    ),
+    (("bigquery",),),
 )
 def test_extension_load(magic_name):
     globalipapp.start_ipython()

--- a/tests/unit/bigquery/test_bigquery.py
+++ b/tests/unit/bigquery/test_bigquery.py
@@ -341,7 +341,6 @@ def test__create_dataset_if_necessary_not_exist():
     ("magic_name",),
     (
         ("bigquery",),
-        ("bqsql",),
     ),
 )
 def test_extension_load(magic_name):


### PR DESCRIPTION
Removes the `%%bqsql` magic alias.

Changes:
- Removed `ipython.register_magic_function` call for `bqsql` in `bigquery_magics/__init__.py`.
- Removed `%%bqsql` references from `bigquery_magics/bigquery.py` docstring.
- Removed `bqsql` from `test_extension_load` parametrization in `tests/unit/bigquery/test_bigquery.py`.
- Removed `%%bqsql` references and examples from `README.rst` and `docs/magics.rst`.

---
*PR created automatically by Jules for task [18023458691533748703](https://jules.google.com/task/18023458691533748703) started by @tswast*