### PR TITLE
chore: librarian release pull request: 20260210T162458Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: bigquery-magics
-    version: 0.11.0
+    version: 0.12.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 [1]: https://pypi.org/project/bigquery-magics/#history
 
+## [0.12.0](https://github.com/googleapis/google-cloud-python/compare/bigquery-magics-v0.11.0...bigquery-magics-v0.12.0) (2026-02-10)
+
+
+### Features
+
+* support schema view (#211) ([8e1883ee553a5ca4a31c0ad3affbbfd96433a6d2](https://github.com/googleapis/google-cloud-python/commit/8e1883ee553a5ca4a31c0ad3affbbfd96433a6d2))
+* remove bqsql magic to make that name available for bigframes (#210) ([c46c94af3a7e8d9632e2abed0198bc070a1fa2cf](https://github.com/googleapis/google-cloud-python/commit/c46c94af3a7e8d9632e2abed0198bc070a1fa2cf))
+
+
+### Bug Fixes
+
+* reduce conflicts between Spanner and BigQuery graph visualization on Colab (#209) ([7dca7b13164953bd07929c5313648184d44a422f](https://github.com/googleapis/google-cloud-python/commit/7dca7b13164953bd07929c5313648184d44a422f))
+
 ## [0.11.0](https://github.com/googleapis/google-cloud-python/compare/bigquery-magics-v0.10.3...bigquery-magics-v0.11.0) (2025-12-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,25 @@
 
 [1]: https://pypi.org/project/bigquery-magics/#history
 
-## [0.12.0](https://github.com/googleapis/google-cloud-python/compare/bigquery-magics-v0.11.0...bigquery-magics-v0.12.0) (2026-02-10)
+## [0.12.0](https://github.com/googleapis/python-bigquery-magics/compare/bigquery-magics-v0.11.0...bigquery-magics-v0.12.0) (2026-02-10)
 
 
 ### Features
 
-* support schema view (#211) ([8e1883ee553a5ca4a31c0ad3affbbfd96433a6d2](https://github.com/googleapis/google-cloud-python/commit/8e1883ee553a5ca4a31c0ad3affbbfd96433a6d2))
-* remove bqsql magic to make that name available for bigframes (#210) ([c46c94af3a7e8d9632e2abed0198bc070a1fa2cf](https://github.com/googleapis/google-cloud-python/commit/c46c94af3a7e8d9632e2abed0198bc070a1fa2cf))
+* support schema view (#211) ([8e1883ee553a5ca4a31c0ad3affbbfd96433a6d2](https://github.com/googleapis/python-bigquery-magics/commit/8e1883ee553a5ca4a31c0ad3affbbfd96433a6d2))
+* remove bqsql magic to make that name available for bigframes (#210) ([c46c94af3a7e8d9632e2abed0198bc070a1fa2cf](https://github.com/googleapis/python-bigquery-magics/commit/c46c94af3a7e8d9632e2abed0198bc070a1fa2cf))
 
 
 ### Bug Fixes
 
-* reduce conflicts between Spanner and BigQuery graph visualization on Colab (#209) ([7dca7b13164953bd07929c5313648184d44a422f](https://github.com/googleapis/google-cloud-python/commit/7dca7b13164953bd07929c5313648184d44a422f))
+* reduce conflicts between Spanner and BigQuery graph visualization on Colab (#209) ([7dca7b13164953bd07929c5313648184d44a422f](https://github.com/googleapis/python-bigquery-magics/commit/7dca7b13164953bd07929c5313648184d44a422f))
 
-## [0.11.0](https://github.com/googleapis/google-cloud-python/compare/bigquery-magics-v0.10.3...bigquery-magics-v0.11.0) (2025-12-16)
+## [0.11.0](https://github.com/googleapis/python-bigquery-magics/compare/bigquery-magics-v0.10.3...bigquery-magics-v0.11.0) (2025-12-16)
 
 
 ### Features
 
-* support python 3.14 (#165) ([8ee73ecf20636eed124b80f76a364ca990acd5fe](https://github.com/googleapis/google-cloud-python/commit/8ee73ecf20636eed124b80f76a364ca990acd5fe))
+* support python 3.14 (#165) ([8ee73ecf20636eed124b80f76a364ca990acd5fe](https://github.com/googleapis/python-bigquery-magics/commit/8ee73ecf20636eed124b80f76a364ca990acd5fe))
 
 ## [0.10.3](https://github.com/googleapis/python-bigquery-magics/compare/v0.10.2...v0.10.3) (2025-08-21)
 

--- a/bigquery_magics/version.py
+++ b/bigquery_magics/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>bigquery-magics: 0.12.0</summary>

## [0.12.0](https://github.com/googleapis/python-bigquery-magics/compare/v0.11.0...v0.12.0) (2026-02-10)

### Features

* support schema view (#211) ([8e1883ee](https://github.com/googleapis/python-bigquery-magics/commit/8e1883ee))

* remove bqsql magic to make that name available for bigframes (#210) ([c46c94af](https://github.com/googleapis/python-bigquery-magics/commit/c46c94af))

### Bug Fixes

* reduce conflicts between Spanner and BigQuery graph visualization on Colab (#209) ([7dca7b13](https://github.com/googleapis/python-bigquery-magics/commit/7dca7b13))

</details>