### PR TITLE
chore: librarian release pull request: 20260225T215852Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:160860d189ff1c2f7515638478823712fa5b243e27ccc33a2728669fa1e2ed0c
 libraries:
   - id: bigquery-magics
-    version: 0.12.0
+    version: 0.12.1
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/bigquery-magics/#history
 
+## [0.12.1](https://github.com/googleapis/python-bigquery-magics/compare/v0.12.0...v0.12.1) (2026-02-25)
+
+
+### Bug Fixes
+
+* usability improvement to the graph visualizer (#215) ([7655ada777d16f6514040747855fd1f0e9d77b1b](https://github.com/googleapis/python-bigquery-magics/commit/7655ada777d16f6514040747855fd1f0e9d77b1b))
+
 ## [0.12.0](https://github.com/googleapis/python-bigquery-magics/compare/v0.11.0...v0.12.0) (2026-02-10)
 
 

--- a/bigquery_magics/version.py
+++ b/bigquery_magics/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:160860d189ff1c2f7515638478823712fa5b243e27ccc33a2728669fa1e2ed0c
<details><summary>bigquery-magics: v0.12.1</summary>

## [v0.12.1](https://github.com/googleapis/python-bigquery-magics/compare/v0.12.0...v0.12.1) (2026-02-25)

### Bug Fixes

* usability improvement to the graph visualizer (#215) ([7655ada7](https://github.com/googleapis/python-bigquery-magics/commit/7655ada7))

</details>